### PR TITLE
Added method to return the remote endpoint address

### DIFF
--- a/CoreOSC/CoreOSC.csproj
+++ b/CoreOSC/CoreOSC.csproj
@@ -13,17 +13,17 @@
         <RepositoryUrl>https://github.com/LucHeart/CoreOSC-UTF8-ASYNC</RepositoryUrl>
         <PackageTags>osc async</PackageTags>
         <Company>LucHeart</Company>
-        <AssemblyVersion>1.2.1.0</AssemblyVersion>
-        <FileVersion>1.2.1.0</FileVersion>
+        <AssemblyVersion>1.3.0.0</AssemblyVersion>
+        <FileVersion>1.3.0.0</FileVersion>
         <NeutralLanguage>en</NeutralLanguage>
-        <Version>1.2.1</Version>
+        <Version>1.3.0</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 

--- a/CoreOSC/CoreOSC.csproj
+++ b/CoreOSC/CoreOSC.csproj
@@ -13,10 +13,10 @@
         <RepositoryUrl>https://github.com/LucHeart/CoreOSC-UTF8-ASYNC</RepositoryUrl>
         <PackageTags>osc async</PackageTags>
         <Company>LucHeart</Company>
-        <AssemblyVersion>1.3.0.0</AssemblyVersion>
-        <FileVersion>1.3.0.0</FileVersion>
+        <AssemblyVersion>1.3.1.0</AssemblyVersion>
+        <FileVersion>1.3.1.0</FileVersion>
         <NeutralLanguage>en</NeutralLanguage>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/CoreOSC/IOscListener.cs
+++ b/CoreOSC/IOscListener.cs
@@ -1,9 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 
 namespace LucHeart.CoreOSC;
 
 public interface IOscListener
 {
     public Task<OscMessage> ReceiveMessageAsync();
+
+    public Task<(OscMessage Message, IPEndPoint EndPoint)> ReceiveMessageExAsync();
+
     public Task<OscBundle> ReceiveBundleAsync();
+
+    public Task<(OscBundle Bundle, IPEndPoint EndPoint)> ReceiveBundleExAsync();
 }

--- a/CoreOSC/IOscSender.cs
+++ b/CoreOSC/IOscSender.cs
@@ -1,9 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 
 namespace LucHeart.CoreOSC;
 
 public interface IOscSender
 {
     public Task SendAsync(byte[] message);
+
     public Task SendAsync(IOscPacket packet);
+
+    public Task SendAsync(IPEndPoint endPoint, byte[] message);
+
+    public Task SendAsync(IPEndPoint endPoint, IOscPacket packet);
 }

--- a/CoreOSC/OscDuplex.cs
+++ b/CoreOSC/OscDuplex.cs
@@ -11,8 +11,12 @@ public class OscDuplex : OscListener, IOscSender
     {
         _remoteEndPoint = remoteEndpoint;
     }
-    
+
     public Task SendAsync(byte[] message) => UdpClient.SendAsync(message, message.Length, _remoteEndPoint);
+
     public Task SendAsync(IOscPacket packet) => SendAsync(packet.GetBytes());
-    
+
+    public Task SendAsync(IPEndPoint endPoint, byte[] message) => UdpClient.SendAsync(message, message.Length, endPoint);
+
+    public Task SendAsync(IPEndPoint endPoint, IOscPacket packet) => SendAsync(endPoint, packet.GetBytes());
 }

--- a/CoreOSC/OscListener.cs
+++ b/CoreOSC/OscListener.cs
@@ -20,10 +20,22 @@ public class OscListener : IDisposable, IOscListener
         return OscMessage.ParseMessage(receiveResult.Buffer);
     }
 
+    public async Task<(OscMessage Message, IPEndPoint EndPoint)> ReceiveMessageExAsync()
+    {
+        var receiveResult = await UdpClient.ReceiveAsync();
+        return (OscMessage.ParseMessage(receiveResult.Buffer), receiveResult.RemoteEndPoint);
+    }
+
     public async Task<OscBundle> ReceiveBundleAsync()
     {
         var receiveResult = await UdpClient.ReceiveAsync();
         return OscBundle.ParseBundle(receiveResult.Buffer);
+    }
+
+    public async Task<(OscBundle Bundle, IPEndPoint EndPoint)> ReceiveBundleExAsync()
+    {
+        var receiveResult = await UdpClient.ReceiveAsync();
+        return (OscBundle.ParseBundle(receiveResult.Buffer), receiveResult.RemoteEndPoint);
     }
 
     public void Dispose()

--- a/CoreOSC/OscSender.cs
+++ b/CoreOSC/OscSender.cs
@@ -20,7 +20,11 @@ public class OscSender : IDisposable, IOscSender
     public Task SendAsync(byte[] message) => _sock.SendToAsync(message, SocketFlags.None, _remoteIpEndPoint);
 
     public Task SendAsync(IOscPacket packet) => SendAsync(packet.GetBytes());
-    
+
+    public Task SendAsync(IPEndPoint endPoint, byte[] message) => _sock.SendToAsync(message, SocketFlags.None, endPoint);
+
+    public Task SendAsync(IPEndPoint endPoint, IOscPacket packet) => SendAsync(endPoint, packet.GetBytes());
+
     public void Dispose()
     {
         _sock.Dispose();


### PR DESCRIPTION
I have a use case where I need to know the IP and port of the clients that sends me OSC messages (so I can send feedback out). I've added two new methods to support this, should be 100% backwards compatible.
Also would it make sense to add the issue tracking feature to your repo?