### PR TITLE
Increase accuracy and speed of TimeTag conversions

### DIFF
--- a/CoreOSC.Tests/TimetagTest.cs
+++ b/CoreOSC.Tests/TimetagTest.cs
@@ -8,12 +8,14 @@ public class TimetagTest
     [Fact]
     public void TestTimetag()
     {
-        var time = (ulong) 60 * 60 * 24 * 365 * 108;
-        time <<= 32;
-        time += (ulong)(Math.Pow(2, 32) / 2);
-        var date = Utils.TimeTagToDateTime(time);
+        ulong tag = 0;
 
-        Assert.Equal(DateTime.Parse("2007-12-06 00:00:00.500"), date);
+        tag |= (ulong)3424309443 << 32; // https://www.timeanddate.com/date/durationresult.html?d1=1&m1=1&y1=1900&d2=6&m2=7&y2=2008&h1=0&i1=0&s1=0&h2=5&i2=4&s2=3
+        tag |= (ulong)(0xFFFFFFFF / 10); // 100ms
+
+        var date = Utils.TimeTagToDateTime(tag);
+
+        Assert.Equal(DateTime.Parse("2008-7-06 05:04:03.100"), date);
     }
 
     [Fact]
@@ -29,5 +31,6 @@ public class TimetagTest
         Assert.Equal(dt.Minute, dtBack.Minute);
         Assert.Equal(dt.Second, dtBack.Second);
         Assert.Equal(dt.Millisecond, dtBack.Millisecond);
+        Assert.Equal(dt.Microsecond, dtBack.Microsecond);
     }
 }

--- a/CoreOSC/TimeTag.cs
+++ b/CoreOSC/TimeTag.cs
@@ -8,10 +8,24 @@ public struct TimeTag
 
     public ulong Tag;
 
+    /// <summary>
+    /// Gets or sets the timestamp from a DateTime. DateTime has an accuracy down to 100 nanoseconds (100'000
+    /// picoseconds)
+    /// </summary>
     public DateTime Timestamp
     {
         get => Utils.TimeTagToDateTime(Tag);
         set => Tag = Utils.DateTimeToTimeTag(value);
+    }
+
+    /// <summary>
+    /// Gets or sets the total seconds in the timestamp. the double precision number is multiplied by 2^32
+    /// giving an accuracy down to about 230 picoseconds ( 1/(2^32) of a second)
+    /// </summary>
+    public double Seconds
+    {
+        get => Utils.TimeTagToSeconds(Tag);
+        set => Tag = Utils.SecondsToTimeTag(value);
     }
 
     /// <summary>
@@ -21,7 +35,7 @@ public struct TimeTag
     public double Fraction
     {
         get => Utils.TimeTagToFraction(Tag);
-        set => Tag = Utils.FractionToTimeTag(value);
+        set => Tag = Utils.SecondsToTimeTag(value);
     }
 
     public TimeTag(ulong value)

--- a/CoreOSC/TimeTag.cs
+++ b/CoreOSC/TimeTag.cs
@@ -4,6 +4,8 @@ namespace LucHeart.CoreOSC;
 
 public struct TimeTag
 {
+    public static TimeTag Immediate => new(1);
+
     public ulong Tag;
 
     public DateTime Timestamp
@@ -19,7 +21,7 @@ public struct TimeTag
     public double Fraction
     {
         get => Utils.TimeTagToFraction(Tag);
-        set => Tag = (Tag & 0xFFFFFFFF00000000) + (uint)(value * 0xFFFFFFFF);
+        set => Tag = Utils.FractionToTimeTag(value);
     }
 
     public TimeTag(ulong value)

--- a/CoreOSC/Utils.cs
+++ b/CoreOSC/Utils.cs
@@ -22,14 +22,6 @@ public static class Utils
         return new DateTime(EpochTicks + secondsTicks + fractionTicks);
     }
 
-    public static double TimeTagToFraction(ulong val)
-    {
-        if (val == 1)
-            return 0.0;
-
-        return (double)val / OscTicksPerSecond;
-    }
-
     public static ulong DateTimeToTimeTag(DateTime value)
     {
         long ticks = value.Ticks - EpochTicks;
@@ -44,9 +36,25 @@ public static class Utils
         return secondTicks | fractionTicks;
     }
 
-    public static ulong FractionToTimeTag(double value)
+    public static double TimeTagToSeconds(ulong val)
+    {
+        if (val == 1)
+            return 0.0;
+
+        return (double)val / OscTicksPerSecond;
+    }
+
+    public static ulong SecondsToTimeTag(double value)
     {
         return (ulong)(value * OscTicksPerSecond);
+    }
+
+    public static double TimeTagToFraction(ulong val)
+    {
+        if (val == 1)
+            return 0.0;
+
+        return (double)(val & 0xFFFFFFFF) / OscTicksPerSecond;
     }
 
     public static int AlignedStringLength(string val)


### PR DESCRIPTION
With this microseconds are now preserved and conversions are 167 times faster in benchmarks