### PR TITLE
Add XML documentation for OSC interfaces and implementations

### DIFF
--- a/CoreOSC/IOscListener.cs
+++ b/CoreOSC/IOscListener.cs
@@ -4,13 +4,36 @@ using System.Threading.Tasks;
 
 namespace LucHeart.CoreOSC;
 
+/// <summary>
+/// Provides asynchronous operations for receiving OSC messages and bundles.
+/// </summary>
 public interface IOscListener
 {
+    /// <summary>
+    /// Receives the next OSC message from the listening endpoint.
+    /// </summary>
+    /// <param name="ct">A token used to cancel the receive operation.</param>
+    /// <returns>A task that resolves to the next <see cref="OscMessage"/>.</returns>
     public Task<OscMessage> ReceiveMessageAsync(CancellationToken ct);
 
+    /// <summary>
+    /// Receives the next OSC message together with the originating endpoint information.
+    /// </summary>
+    /// <param name="ct">A token used to cancel the receive operation.</param>
+    /// <returns>A task that resolves to the received <see cref="OscMessage"/> and its sender endpoint.</returns>
     public Task<(OscMessage Message, IPEndPoint EndPoint)> ReceiveMessageExAsync(CancellationToken ct);
 
+    /// <summary>
+    /// Receives the next OSC bundle from the listening endpoint.
+    /// </summary>
+    /// <param name="ct">A token used to cancel the receive operation.</param>
+    /// <returns>A task that resolves to the next <see cref="OscBundle"/>.</returns>
     public Task<OscBundle> ReceiveBundleAsync(CancellationToken ct);
 
+    /// <summary>
+    /// Receives the next OSC bundle together with the originating endpoint information.
+    /// </summary>
+    /// <param name="ct">A token used to cancel the receive operation.</param>
+    /// <returns>A task that resolves to the received <see cref="OscBundle"/> and its sender endpoint.</returns>
     public Task<(OscBundle Bundle, IPEndPoint EndPoint)> ReceiveBundleExAsync(CancellationToken ct);
 }

--- a/CoreOSC/IOscPacket.cs
+++ b/CoreOSC/IOscPacket.cs
@@ -1,6 +1,13 @@
 ﻿namespace LucHeart.CoreOSC;
 
+/// <summary>
+/// Represents an Open Sound Control packet that can be serialized for transmission.
+/// </summary>
 public interface IOscPacket
 {
+    /// <summary>
+    /// Converts the packet into its OSC binary representation.
+    /// </summary>
+    /// <returns>The serialized OSC byte sequence.</returns>
     public byte[] GetBytes();
 }

--- a/CoreOSC/IOscSender.cs
+++ b/CoreOSC/IOscSender.cs
@@ -3,13 +3,38 @@ using System.Threading.Tasks;
 
 namespace LucHeart.CoreOSC;
 
+/// <summary>
+/// Provides asynchronous operations for sending OSC packets to remote endpoints.
+/// </summary>
 public interface IOscSender
 {
+    /// <summary>
+    /// Sends a raw OSC message payload to the configured default endpoint.
+    /// </summary>
+    /// <param name="message">The binary OSC message payload to send.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendAsync(byte[] message);
 
+    /// <summary>
+    /// Serializes and sends an OSC packet to the configured default endpoint.
+    /// </summary>
+    /// <param name="packet">The OSC packet to serialize and send.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendAsync(IOscPacket packet);
 
+    /// <summary>
+    /// Sends a raw OSC message payload to a specific endpoint.
+    /// </summary>
+    /// <param name="endPoint">The destination endpoint that should receive the message.</param>
+    /// <param name="message">The binary OSC message payload to send.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendAsync(IPEndPoint endPoint, byte[] message);
 
+    /// <summary>
+    /// Serializes and sends an OSC packet to a specific endpoint.
+    /// </summary>
+    /// <param name="endPoint">The destination endpoint that should receive the packet.</param>
+    /// <param name="packet">The OSC packet to serialize and send.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendAsync(IPEndPoint endPoint, IOscPacket packet);
 }

--- a/CoreOSC/IOscSerializable.cs
+++ b/CoreOSC/IOscSerializable.cs
@@ -1,6 +1,13 @@
 ﻿namespace LucHeart.CoreOSC;
 
+/// <summary>
+/// Represents a value that can be serialized into the OSC binary wire format.
+/// </summary>
 public interface IOscSerializable
 {
+    /// <summary>
+    /// Converts the current value into its OSC binary representation.
+    /// </summary>
+    /// <returns>The serialized OSC byte sequence.</returns>
     public byte[] ToBytes();
 }

--- a/CoreOSC/Midi.cs
+++ b/CoreOSC/Midi.cs
@@ -28,6 +28,7 @@ public readonly struct Midi : IOscSerializable
     public override int GetHashCode() => (Port << 24) + (Status << 16) + (Data1 << 8) + (Data2);
 
 
+    /// <inheritdoc />
     public byte[] ToBytes()
     {
         var output = new byte[4];

--- a/CoreOSC/OscBundle.cs
+++ b/CoreOSC/OscBundle.cs
@@ -33,6 +33,7 @@ public sealed class OscBundle : IOscPacket
     private const string BundleName = "#bundle";
     private static readonly int BundleTagLen = Utils.AlignedStringLength(BundleName);
     
+    /// <inheritdoc />
     public byte[] GetBytes()
     {
         var outMessages = Messages.Select(msg => msg.GetBytes()).ToArray();

--- a/CoreOSC/OscDuplex.cs
+++ b/CoreOSC/OscDuplex.cs
@@ -12,11 +12,15 @@ public class OscDuplex : OscListener, IOscSender
         _remoteEndPoint = remoteEndpoint;
     }
 
+    /// <inheritdoc />
     public Task SendAsync(byte[] message) => UdpClient.SendAsync(message, message.Length, _remoteEndPoint);
 
+    /// <inheritdoc />
     public Task SendAsync(IOscPacket packet) => SendAsync(packet.GetBytes());
 
+    /// <inheritdoc />
     public Task SendAsync(IPEndPoint endPoint, byte[] message) => UdpClient.SendAsync(message, message.Length, endPoint);
 
+    /// <inheritdoc />
     public Task SendAsync(IPEndPoint endPoint, IOscPacket packet) => SendAsync(endPoint, packet.GetBytes());
 }

--- a/CoreOSC/OscListener.cs
+++ b/CoreOSC/OscListener.cs
@@ -43,6 +43,11 @@ public class OscListener : IDisposable, IOscListener
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see cref="EnableTransparentBundleToMessageConversion"/> is <see langword="true"/>, bundle contents are
+    /// transparently dequeued and returned as individual messages.
+    /// </remarks>
     public async Task<OscMessage> ReceiveMessageAsync(CancellationToken ct = default)
     {
         if (EnableTransparentBundleToMessageConversion)
@@ -76,6 +81,7 @@ public class OscListener : IDisposable, IOscListener
         }
     }
 
+    /// <inheritdoc />
     public async Task<(OscMessage Message, IPEndPoint EndPoint)> ReceiveMessageExAsync(CancellationToken ct = default)
     {
 #if !NETSTANDARD
@@ -86,6 +92,7 @@ public class OscListener : IDisposable, IOscListener
         return (OscMessage.ParseMessage(receiveResult.Buffer), receiveResult.RemoteEndPoint);
     }
 
+    /// <inheritdoc />
     public async Task<OscBundle> ReceiveBundleAsync(CancellationToken ct = default)
     {
 #if !NETSTANDARD
@@ -96,6 +103,7 @@ public class OscListener : IDisposable, IOscListener
         return OscBundle.ParseBundle(receiveResult.Buffer);
     }
 
+    /// <inheritdoc />
     public async Task<(OscBundle Bundle, IPEndPoint EndPoint)> ReceiveBundleExAsync(CancellationToken ct = default)
     {
 #if !NETSTANDARD

--- a/CoreOSC/OscMessage.cs
+++ b/CoreOSC/OscMessage.cs
@@ -17,6 +17,7 @@ public sealed class OscMessage : IOscPacket
         Arguments = args;
     }
 
+    /// <inheritdoc />
     public byte[] GetBytes()
     {
         var parts = new List<byte[]>();

--- a/CoreOSC/OscSender.cs
+++ b/CoreOSC/OscSender.cs
@@ -17,12 +17,16 @@ public class OscSender : IDisposable, IOscSender
         _sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
     }
 
+    /// <inheritdoc />
     public Task SendAsync(byte[] message) => _sock.SendToAsync(message, SocketFlags.None, _remoteIpEndPoint);
 
+    /// <inheritdoc />
     public Task SendAsync(IOscPacket packet) => SendAsync(packet.GetBytes());
 
+    /// <inheritdoc />
     public Task SendAsync(IPEndPoint endPoint, byte[] message) => _sock.SendToAsync(message, SocketFlags.None, endPoint);
 
+    /// <inheritdoc />
     public Task SendAsync(IPEndPoint endPoint, IOscPacket packet) => SendAsync(endPoint, packet.GetBytes());
 
     public void Dispose()

--- a/CoreOSC/RGBA.cs
+++ b/CoreOSC/RGBA.cs
@@ -27,6 +27,7 @@ public readonly struct RGBA : IOscSerializable
     public static bool operator !=(RGBA a, RGBA b) => !a.Equals(b);
     public override int GetHashCode() => (R << 24) + (G << 16) + (B << 8) + A;
 
+    /// <inheritdoc />
     public byte[] ToBytes()
     {
         var output = new byte[4];

--- a/CoreOSC/Symbol.cs
+++ b/CoreOSC/Symbol.cs
@@ -12,6 +12,7 @@ public readonly struct Symbol : IOscSerializable
     }
 
     public override string ToString() => Value;
+    /// <inheritdoc />
     public byte[] ToBytes()
     {
         var bytes = Encoding.UTF8.GetBytes(Value);


### PR DESCRIPTION
## Summary
- add XML documentation comments to OSC interfaces
- inherit the interface documentation in the associated implementations and add context where needed
- propagate serialization documentation to value types implementing IOscSerializable

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de9044875083278aab5dfddbaa0455